### PR TITLE
Update yolo data loader for grayscale

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -2096,8 +2096,11 @@ class Format:
             >>> print(formatted_img.shape)
             torch.Size([3, 100, 100])
         """
+        # Ensure image has channel dimension and replicate to 3 channels if grayscale
         if len(img.shape) < 3:
             img = np.expand_dims(img, -1)
+        if img.shape[2] == 1:
+            img = np.repeat(img, 3, axis=2)
         img = img.transpose(2, 0, 1)
         img = np.ascontiguousarray(img[::-1] if random.uniform(0, 1) > self.bgr else img)
         img = torch.from_numpy(img)

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1363,6 +1363,9 @@ class RandomHSV:
             >>> augmented_img = labels["img"]
         """
         img = labels["img"]
+        # Skip HSV augmentation for grayscale images (single channel)
+        if img.ndim < 3 or img.shape[2] < 3:
+            return labels
         if self.hgain or self.sgain or self.vgain:
             r = np.random.uniform(-1, 1, 3) * [self.hgain, self.sgain, self.vgain] + 1  # random gains
             hue, sat, val = cv2.split(cv2.cvtColor(img, cv2.COLOR_BGR2HSV))

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -2096,11 +2096,9 @@ class Format:
             >>> print(formatted_img.shape)
             torch.Size([3, 100, 100])
         """
-        # Ensure image has channel dimension and replicate to 3 channels if grayscale
+        # Ensure image has channel dimension (for grayscale images)
         if len(img.shape) < 3:
             img = np.expand_dims(img, -1)
-        if img.shape[2] == 1:
-            img = np.repeat(img, 3, axis=2)
         img = img.transpose(2, 0, 1)
         img = np.ascontiguousarray(img[::-1] if random.uniform(0, 1) > self.bgr else img)
         img = torch.from_numpy(img)

--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -158,9 +158,14 @@ class BaseDataset(Dataset):
                     Path(fn).unlink(missing_ok=True)
                     im = cv2.imread(f)  # BGR
             else:  # read image
-                im = cv2.imread(f)  # BGR
-            if im is None:
-                raise FileNotFoundError(f"Image Not Found {f}")
+                im = cv2.imread(f)  # BGR or grayscale
+
+                if im is None:
+                    raise FileNotFoundError(f"Image Not Found {f}")
+
+            # Ensure image has channel dimension (supports grayscale)
+            if im.ndim == 2:  # grayscale image, add channel dimension
+                im = np.expand_dims(im, -1)
 
             h0, w0 = im.shape[:2]  # orig hw
             if rect_mode:  # resize long side to imgsz while maintaining aspect ratio


### PR DESCRIPTION
Add support for 1-channel grayscale images in the YOLO data loader to enable training with grayscale datasets.

---

[Open in Web](https://cursor.com/agents?id=bc-4711cb40-6a0b-4b4f-a6e6-cce473f593c6) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-4711cb40-6a0b-4b4f-a6e6-cce473f593c6) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)