### PR TITLE
Fix raytune attribute error in training

### DIFF
--- a/ultralytics/utils/callbacks/raytune.py
+++ b/ultralytics/utils/callbacks/raytune.py
@@ -14,7 +14,15 @@ except (ImportError, AssertionError):
 
 def on_fit_epoch_end(trainer):
     """Sends training metrics to Ray Tune at end of each epoch."""
-    if ray.train._internal.session._get_session():  # replacement for deprecated ray.tune.is_session_enabled()
+    # Handle both older (<2.7) and newer (>=2.7) Ray versions where the session accessor changed
+    ray_session_mod = ray.train._internal.session
+    if hasattr(ray_session_mod, "_get_session"):
+        _sess = ray_session_mod._get_session()
+    else:
+        # Fallback for newer Ray versions that expose get_session()
+        _sess = ray_session_mod.get_session()
+
+    if _sess:  # Only report if we're inside an active Ray Tune session
         metrics = trainer.metrics
         metrics["epoch"] = trainer.epoch
         session.report(metrics)


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update Ray Tune callback to support recent Ray versions and prevent training crashes.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `ray.train._internal.session._get_session()` method was renamed to `get_session()` in Ray versions >= 2.7. This change caused an `AttributeError` and crashed training when the callback was executed. The fix adds a compatibility check to use the correct method based on the installed Ray version.

---

[Open in Web](https://cursor.com/agents?id=bc-42085b27-cb8f-4764-b651-5daf531be126) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-42085b27-cb8f-4764-b651-5daf531be126) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)